### PR TITLE
Allow to process commits in reverse chronological order.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and finally compile. Or you just do the same with one command:
 
 
 ``` bash
-$ ./gradle-each --gradle-tasks "clean assembleDebug" --from-hash master --till-hash feature-branch
+$ ./gradle-each --gradle-tasks "clean assembleDebug" --from-hash master --till-hash feature-branch --reverse-order false
 ```
 
 The parameters explained:
@@ -28,6 +28,8 @@ The parameters explained:
   This parameter is optional - the default value is `master`.
 * `-t|--till-hash` The branch name e.g. `feature-branch` or the hash of the last commit on that branch e.g. `F`. 
   This parameter is optional - the default value is `HEAD`.
+* `-r|--reverse-order` To process commits in reverse chronological order pass `true`.
+This parameter is optional - the default value is `false`.
 
 ## Author
 


### PR DESCRIPTION
- Introduce `--reverse-order` parameter.